### PR TITLE
Fixed a bug when a platform in es_systems.cfg doesn't exist in TheGameDbPlatforms.xml

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -431,9 +431,9 @@ def autoChooseBestResult(nodes,t):
 
 
 def getPlatformNames(_platforms):
-    platforms = _platforms.split(',')
-    for (i, platform) in enumerate(platforms):
-        if gamesdb_platforms[platform] is not None: platforms[i] = gamesdb_platforms[platform]
+    platforms = []
+    for (i, platform) in enumerate(_platforms.split(',')):
+        if gamesdb_platforms.get(platform, None) is not None: platforms.append(gamesdb_platforms[platform])
     return platforms
 
 


### PR DESCRIPTION
Hi,

When a platform doesn't exist in TheGameDbPlatforms.xml the script throws this message and ends:
Traceback (most recent call last):
  File "scraper.py", line 665, in <module>
    scanFiles(ES_systems[i])
  File "scraper.py", line 448, in scanFiles
    platforms = getPlatformNames(SystemInfo[3])
  File "scraper.py", line 436, in getPlatformNames
    if gamesdb_platforms[platform] is not None: platforms[i] = gamesdb_platforms[platform]
KeyError: 'apple2'

In the original code, the list "platforms" is initialized with every platform found in es_systems.cfg (line 434), and then in line 436 it substitutes that value with the code found in TheGameDbPlatforms.xml. But if the platform doesn't exists in the TheGameDbPlatforms.xml, then we get the key error shown above.

Using the get method solves the problem. Also, the list must be initialized empty so only the available platforms are added, otherwise it will fail again later.
