### PR TITLE
Fixing crash bug for None-type _platforms

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -432,8 +432,9 @@ def autoChooseBestResult(nodes,t):
 
 def getPlatformNames(_platforms):
     platforms = []
-    for (i, platform) in enumerate(_platforms.split(',')):
-        if gamesdb_platforms.get(platform, None) is not None: platforms.append(gamesdb_platforms[platform])
+    if (_platforms is not None):
+        for (i, platform) in enumerate(_platforms.split(',')):
+            if gamesdb_platforms.get(platform, None) is not None: platforms.append(gamesdb_platforms[platform])
     return platforms
 
 


### PR DESCRIPTION
I came across this using beta 3 of RetroPie 3.0, which adds a new configuration item to the list of platforms and causes this bug. 
