### PR TITLE
Fix SyntaxError. Closes #10

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -432,7 +432,7 @@ def autoChooseBestResult(nodes,t):
 
 def getPlatformNames(_platforms):
     platforms = []
-    for (i, platform) in enumerate(ES_systems)):
+    for (i, platform) in enumerate(ES_systems):
         if gamesdb_platforms.get(platform, None) is not None: platforms.append(gamesdb_platforms[platform])
     return platforms
 


### PR DESCRIPTION
It had an extra closing parenthesis causing SyntaxError. Fixes #10 

```
File "scraper.py", line 437
    for (i, platform) in enumerate(ES_systems)):
                                              ^
SyntaxError: invalid syntax
```
