### PR TITLE
Fix structure of generated gamelist.xml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ $ python scraper.py -pisize -l
 ```
 
 same as above, but the script will only use the first result if it is a perfect match
-
 ```
 $ python scraper.py -pisize -l -minscore 100
 ```
 
+same as above, but the script will prompt each ROM
 ```
 $ python scraper.py -pisize
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ optional arguments:
   -v          verbose output
   -f          force re-scraping (ignores and overwrites the current gamelist)
   -p          partial scraping (per console)
-  -l          i'm feeling lucky (use first result if the score is greater than 1)
+  -l          i'm feeling lucky (use first result if the score is greater than minscore)
+  -minscore   defines the minimum score used by -l
+              - defaults to 1
   -name       the "name" from es_settings.cfg - this sets the path for the gamelist
               - must be used with platform option
               (ex: mame)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,12 @@ on RetroPie, this is the easiest, fastest way to run the script
 $ python scraper.py -pisize -l
 ```
 
-same as above, but the script will prompt each ROM
+same as above, but the script will only use the first result if it is a perfect match
+
+```
+$ python scraper.py -pisize -l -minscore 100
+```
+
 ```
 $ python scraper.py -pisize
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ optional arguments:
   -f          force re-scraping (ignores and overwrites the current gamelist)
   -p          partial scraping (per console)
   -l          i'm feeling lucky (use first result if the score is greater than 1)
-  -name       the "name" from es_settings.cfg - this sets the path for the gamelsit
+  -name       the "name" from es_settings.cfg - this sets the path for the gamelist
               - must be used with platform option
               (ex: mame)
   -platform   Platform Name from http://www.emulationstation.org/gettingstarted.html 
@@ -27,9 +27,11 @@ optional arguments:
   -rompath    optional path to ROMs - if not supplied, rompath is build from name option
               - used with name and platform arguments
               (ex: ~/RetroPie/roms/mame)
-  -ext        option extension list for ROMs - if not supplied, all files are matched
+  -ext        optional extension list for ROMs - if not supplied, all files are matched
               - used with name and platform arguments
               (ex: ".zip .ZIP")
+  -accurate   improve accuracy by searching for each game individually
+              - this is a lot slower, but gives better results
 ```
 
 Quick script written in Python that uses various online sources to scrape artwork and game info and saves it as XML files to be read by EmulationStation.

--- a/scraper.py
+++ b/scraper.py
@@ -234,7 +234,7 @@ def getGameInfo(file, platforms, gamelists):
             results = gamelists[i].findall('Game')
 
         # Search for matching title options
-        if len(results) > 1:
+        if len(results) > 0:
             options.extend(getTitleOptions(title, results))
 
 

--- a/scraper.py
+++ b/scraper.py
@@ -29,6 +29,7 @@ parser.add_argument("-v", help="verbose output", action='store_true')
 parser.add_argument("-f", help="force re-scraping (ignores and overwrites the current gamelist)", action='store_true')
 parser.add_argument("-p", help="partial scraping (per console)", action='store_true')
 parser.add_argument("-l", help="i'm feeling lucky (use first result)", action='store_true')
+parser.add_argument("-minscore", metavar="score", help="defines the minimum score used by -l (defaults to 1)", type=int)
 parser.add_argument("-name", help="manually specify a name, ignore es_settings.cfg (must be used with -platform)", type=str)
 parser.add_argument("-rompath", help="manually specify a path, ignore es_settings.cfg (used with -name and -platform)", type=str)
 parser.add_argument("-platform", help="manually specify a platform for ROMs in 'rompath', ignore es_settings.cfg (must be used with -name", type=str)
@@ -44,6 +45,7 @@ GAMESLIST_URL = GAMESDB_BASE + "GetGamesList.php"
 
 DEFAULT_WIDTH  = 375
 DEFAULT_HEIGHT = 350
+DEFAULT_SCORE  = 1
 
 gamesdb_platforms = {}
 
@@ -213,7 +215,7 @@ def getGameInfo(file, platforms, gamelists):
                 game_rank = 95
             # - Give high (90) rank to results that appear entirely in titles
             elif check_title.lower() in scrubbed_title.lower():
-                game_rank = 90				
+                game_rank = 90                
             # - Otherwise, rank title by number of occurrences of words
             else:
                 #print "%s" % '|'.join(word_list)
@@ -243,9 +245,10 @@ def getGameInfo(file, platforms, gamelists):
         # * I'm feeling lucky - select first result
         if args.l:
             if not options:     # If no options available, return None
+                print "no matches found"
                 return None
-            if options[0][0] == 1:
-                print "match not high enough"
+            if options[0][0] < args.minscore:
+                print "best score (%s) is below the minmium (%s)" % (options[0][0], args.minscore)
                 return None
             else:
                 result = options[0]
@@ -663,7 +666,11 @@ else:
 if args.noimg:
     print "Boxart downloading disabled."
 if args.f:
-    print "Re-scraping all games.."
+    print "Re-scraping all games."
+if args.l:
+    if not args.minscore:
+        args.minscore = DEFAULT_SCORE
+    print "I'm feeling lucky enabled. Minimum score of %s." % args.minscore
 if args.v:
     print "Verbose mode enabled."
 if args.p:

--- a/scraper.py
+++ b/scraper.py
@@ -452,8 +452,9 @@ def autoChooseBestResult(nodes,t):
 
 def getPlatformNames(_platforms):
     platforms = []
-    for (i, platform) in enumerate(_platforms.split(',')):
-        if gamesdb_platforms.get(platform, None) is not None: platforms.append(gamesdb_platforms[platform])
+    if _platforms:
+        for (i, platform) in enumerate(_platforms.split(',')):
+            if gamesdb_platforms.get(platform, None) is not None: platforms.append(gamesdb_platforms[platform])
     return platforms
 
 


### PR DESCRIPTION
This change updates the generated gamelist.xml files to be compatible with the latest version of EmulationStation that is provided as part of RetroPie 3.0.

The changes are:
- Don't write the <id> element since ES doesn't expect to find it
- Rating should be divided by 10 and formatted to 2 decimal places
- Release date should be in XML date format
- The <genre> element should be a single element, not nested under <genres>
- Elements are only appended when they have data so that ES will use its default values rather than blanks
