### PR TITLE
Fix scanFiles bug

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -705,7 +705,7 @@ else:
     print "Scanning all systems."
 
 for i,v in enumerate(scan_systems):
-	scanFiles(ES_systems[v])
+    scanFiles(v)
 
 print "All done!"
 


### PR DESCRIPTION
In reference to this bug (https://github.com/thadmiller/ES-scraper/issues/16), there seemed to be a problem with the call to the scanFile function. This worked for me.
